### PR TITLE
Make accounts username based rather than UUID based

### DIFF
--- a/db.sql
+++ b/db.sql
@@ -1,2 +1,2 @@
 USE vradio;
-CREATE TABLE accounts (id UUID not null, username varchar(255), email varchar(255), hashed_password varchar(255), verified bool, primary key (id));
+CREATE TABLE accounts (id bigint not null AUTO_INCREMENT, username varchar(255), email varchar(255), hashed_password varchar(255), verified bool, primary key (id));

--- a/src/main/java/tv/vradio/vradiotvserver/account/Account.java
+++ b/src/main/java/tv/vradio/vradiotvserver/account/Account.java
@@ -4,7 +4,6 @@ import lombok.Getter;
 import lombok.Setter;
 
 import javax.persistence.*;
-import java.util.UUID;
 
 @Entity
 @Table(name = "Accounts")
@@ -12,9 +11,9 @@ import java.util.UUID;
 @Setter
 public class Account {
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id")
-    private final UUID id = UUID.randomUUID();
+    private Long id;
 
     @Column(name = "username")
     private String username;

--- a/src/main/java/tv/vradio/vradiotvserver/account/AccountRepository.java
+++ b/src/main/java/tv/vradio/vradiotvserver/account/AccountRepository.java
@@ -12,5 +12,5 @@ public interface AccountRepository extends CrudRepository<Account, UUID> {
     Optional<Account> findByUsername(String username);
     Optional<Account> findByEmail(String email);
 
-    Optional<Account> findById(UUID id);
+    Optional<Account> findById(Long id);
 }

--- a/src/main/java/tv/vradio/vradiotvserver/account/AccountServiceImpl.java
+++ b/src/main/java/tv/vradio/vradiotvserver/account/AccountServiceImpl.java
@@ -8,23 +8,23 @@ import java.util.concurrent.ConcurrentHashMap;
 
 @Service
 public class AccountServiceImpl implements AccountService {
-    private final Map<UUID, String> activeTokens = new ConcurrentHashMap<>();
+    private final Map<String, String> activeTokens = new ConcurrentHashMap<>();
 
     @Override
     public String generateToken(Account account) {
         String token = UUID.randomUUID().toString();
 
-        activeTokens.put(account.getId(), token);
+        activeTokens.put(account.getUsername(), token);
         return token;
     }
 
     @Override
     public boolean confirmToken(Account account, String token) {
-        return activeTokens.containsKey(account.getId()) && activeTokens.get(account.getId()).equals(token);
+        return activeTokens.containsKey(account.getUsername()) && activeTokens.get(account.getUsername()).equals(token);
     }
 
     @Override
     public void deauth(Account account) {
-        activeTokens.remove(account.getId());
+        activeTokens.remove(account.getUsername());
     }
 }

--- a/src/main/java/tv/vradio/vradiotvserver/exceptions/StationNotFoundException.java
+++ b/src/main/java/tv/vradio/vradiotvserver/exceptions/StationNotFoundException.java
@@ -4,6 +4,6 @@ import tv.vradio.vradiotvserver.account.Account;
 
 public class StationNotFoundException extends RuntimeException {
     public StationNotFoundException(Account owner) {
-        super("Could not find station with owner: " + owner.getId().toString());
+        super("Could not find station with owner: " + owner.getUsername());
     }
 }

--- a/src/main/java/tv/vradio/vradiotvserver/stations/Station.java
+++ b/src/main/java/tv/vradio/vradiotvserver/stations/Station.java
@@ -4,13 +4,12 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 import java.util.Queue;
-import java.util.UUID;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
 @RequiredArgsConstructor
 @Getter
 public class Station {
-    private final UUID ownerId;
+    private final String ownerUsername;
 
     private final String name;
     private final Queue<Media> mediaQueue = new ConcurrentLinkedQueue<>();

--- a/src/main/java/tv/vradio/vradiotvserver/stations/StationController.java
+++ b/src/main/java/tv/vradio/vradiotvserver/stations/StationController.java
@@ -12,7 +12,6 @@ import tv.vradio.vradiotvserver.exceptions.AuthenticationFailureException;
 import tv.vradio.vradiotvserver.exceptions.StationNotFoundException;
 
 import java.util.Collection;
-import java.util.UUID;
 
 @RestController
 @RequiredArgsConstructor
@@ -27,8 +26,8 @@ public class StationController {
     }
 
     @GetMapping("/stations/get")
-    public Station get(@RequestParam("owner-id") String ownerId) {
-         Account account = accountRepository.findById(UUID.fromString(ownerId)).orElseThrow(() -> new AccountNotFoundException(ownerId));
+    public Station get(@RequestParam("owner") String owner) {
+         Account account = accountRepository.findByUsername(owner).orElseThrow(() -> new AccountNotFoundException(owner));
 
          if(stationService.hasStation(account)) {
              return stationService.findStation(account);
@@ -39,7 +38,7 @@ public class StationController {
 
     @GetMapping("/stations/create")
     public Station create(@RequestParam("auth-token") String authToken, @RequestParam("owner") String accountOwner, @RequestParam("name") String name) {
-        Account account = accountRepository.findById(UUID.fromString(accountOwner)).orElseThrow(() -> new AccountNotFoundException(accountOwner));
+        Account account = accountRepository.findByUsername(accountOwner).orElseThrow(() -> new AccountNotFoundException(accountOwner));
 
         if(!accountService.confirmToken(account, authToken)) {
             throw new AuthenticationFailureException(authToken);
@@ -48,7 +47,7 @@ public class StationController {
             return stationService.findStation(account);
         }
 
-        Station station = new Station(account.getId(), name);
+        Station station = new Station(account.getUsername(), name);
         stationService.registerStation(station);
         return station;
     }

--- a/src/main/java/tv/vradio/vradiotvserver/stations/StationServiceImpl.java
+++ b/src/main/java/tv/vradio/vradiotvserver/stations/StationServiceImpl.java
@@ -5,16 +5,15 @@ import tv.vradio.vradiotvserver.account.Account;
 
 import java.util.Collection;
 import java.util.Map;
-import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
 @Service
 public class StationServiceImpl implements StationService {
-    private final Map<UUID, Station> stations = new ConcurrentHashMap<>();
+    private final Map<String, Station> stations = new ConcurrentHashMap<>();
 
     @Override
     public Station findStation(Account account) {
-        return stations.get(account.getId());
+        return stations.get(account.getUsername());
     }
 
     @Override
@@ -24,16 +23,16 @@ public class StationServiceImpl implements StationService {
 
     @Override
     public boolean hasStation(Account account) {
-        return stations.containsKey(account.getId());
+        return stations.containsKey(account.getUsername());
     }
 
     @Override
     public void registerStation(Station station) {
-        stations.put(station.getOwnerId(), station);
+        stations.put(station.getOwnerUsername(), station);
     }
 
     @Override
     public void removeStation(Account account) {
-        stations.remove(account.getId());
+        stations.remove(account.getUsername());
     }
 }


### PR DESCRIPTION
Change the account system to be a username based system rather then using UUIDs, the new ID in the database will be a long rather then a UUID. This simplifies the code a lot and makes working with accounts much easier as some weird shenanigans happens with Spring tries to serialize a UUID. @ethionamide @Scr3bL0rd 